### PR TITLE
TASK: Adjust version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Fully featured CORS HTTP component (a.k.a. middleware) for Flow framework to allow "cross-domain" requests.
 
+
+```
+⚡️ Warning
+
+This package is not working with version 7.0 and higher of the Neos/Flow framework.
+In version 7.0 we introduced PSR-15 Middlewares and it is possible to use other PHP libraries instead.
+
+For instance https://github.com/tuupola/cors-middleware
+```
+
+
 ## Background
 
 This package is a implementation of a CORS middleware for Cross-Origin Resource Sharing (see https://developer.mozilla.org/en-US/docs/Glossary/CORS).

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "CORS HTTP component (middleware) for Neos Flow",
     "license": "LGPL-3.0+",
     "require": {
-        "neos/flow": "*"
+        "neos/flow": "^4.0 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As flow version seven has PSR-15 middlewares, this package is not working anymore.
Therefore, this change will limit the usage to version 4.x,  5.x and 6.x of neos/flow.